### PR TITLE
Remove unused imports and variables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Instagram, Book, Video, Code, Briefcase, GraduationCap, Brain, Link2, ExternalLink, Github, Youtube, Linkedin } from 'lucide-react';
+import { Instagram, Book, Video, Code, Briefcase, ExternalLink, Youtube, Linkedin } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface Resource {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -58,8 +58,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeftIcon className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRightIcon className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeftIcon className="h-4 w-4" />,
+        IconRight: () => <ChevronRightIcon className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,10 +1,4 @@
 import * as React from 'react';
-import * as RechartsPrimitive from 'recharts';
-import {
-  NameType,
-  Payload,
-  ValueType,
-} from 'recharts/types/component/DefaultTooltipContent';
 
 import { cn } from '@/lib/utils';
 


### PR DESCRIPTION
Remove unused imports and variables to allow hosting and deployment in AWS Amplify.

* **src/App.tsx**
  - Remove unused imports 'GraduationCap', 'Brain', 'Link2', 'Github' on line 5.

* **src/components/ui/calendar.tsx**
  - Remove unused 'props' declared on lines 61 and 62.

* **src/components/ui/chart.tsx**
  - Remove all unused imports in import declaration on line 3.

