### PR TITLE
Deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -46,6 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        run: npm run deploy

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -57,7 +58,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "gh-pages": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: '/bio-link1/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
Update the repository to make it deployable and perfect for public use.

* **package.json**
  - Add a `deploy` script to deploy the site to GitHub Pages.
  - Add `gh-pages` as a dependency to handle GitHub Pages deployment.

* **.github/workflows/jekyll-gh-pages.yml**
  - Add steps to checkout the repository, set up Node.js, install dependencies, and build the project.
  - Update the workflow to use the `deploy` script from `package.json`.

* **vite.config.ts**
  - Add `base` property to the Vite configuration to set the base URL for GitHub Pages.

